### PR TITLE
Jetpack lateral thrust, Hor+ widescreen, and walk speed

### DIFF
--- a/main/source/cl_dll/hud_update.cpp
+++ b/main/source/cl_dll/hud_update.cpp
@@ -41,7 +41,57 @@ int CHud::UpdateClientData(client_data_t *cdata, float time)
 
 	Think();
 
-	cdata->fov = m_iFOV;
+	//cdata->fov = m_iFOV;
+
+	float width = ScreenWidth();
+	float height = ScreenHeight();
+
+	//horizontal+ widescreen view correction - engine uses vertical-
+	//starts with hacked in commander view fix where commander fov was changed to 106 so the black background beind the map is fully rendered - remove that section and change comm fov back to 90 if fixed
+	if (gHUD.GetIsInTopDownMode())
+	{
+		float commFOV;
+
+		commFOV = atanf(tan(m_iFOV * M_PI / 360) * 0.5625 * width / height) * 360 / M_PI;
+
+		//clamp
+		if (commFOV > 107)
+		{
+			commFOV = 106;
+		}
+		else if (commFOV < 90)
+		{
+			commFOV = 90;
+		}
+
+		cdata->fov = commFOV;
+	}
+	else
+	{
+		float newFOV;
+
+		newFOV = atanf(tan(m_iFOV * M_PI / 360) * 0.75 * width / height) * 360 / M_PI;
+
+		//clamp for game balance
+		if (m_iFOV == 105 && newFOV > 121)
+		{
+			newFOV = 120;
+		}
+		else if (m_iFOV == 100 && newFOV > 117)
+		{
+			newFOV = 116;
+		}
+		else if (m_iFOV == 90 && newFOV > 107)
+		{
+			newFOV = 106;
+		}
+		else if (newFOV < 90)
+		{
+			newFOV = 90;
+		}
+
+		cdata->fov = newFOV;
+	}
 	
 	CL_ResetButtonBits( m_iKeyBits );
 

--- a/main/source/mod/AvHMarineEquipmentConstants.h
+++ b/main/source/mod/AvHMarineEquipmentConstants.h
@@ -84,7 +84,7 @@
 
 // Jetpack
 const float kJetpackForce					= 1250;
-const float	kJetpackLateralScalar			= 12;
+//const float	kJetpackLateralScalar			= 12;
 const float kJetpackEnergyGainRate			= .1f;
 const float kJetpackMinimumEnergyToJetpack	= .1f;
 const float kJetpackEnergyLossRate			= kJetpackEnergyGainRate*1.5f;

--- a/main/source/mod/AvHMovementUtil.cpp
+++ b/main/source/mod/AvHMovementUtil.cpp
@@ -260,26 +260,33 @@ float AvHMUGetWalkSpeedFactor(AvHUser3 inUser3)
 {
 	float theMoveSpeed = .1f;
 	
-	switch(inUser3)
+	//unsolved +speed speed reduction starting with 3.2.1 - these values modified to replicate old movement
+	switch (inUser3)
 	{
 	case AVH_USER3_MARINE_PLAYER:
-		theMoveSpeed = .095f;
+		//theMoveSpeed = .095f;
+		theMoveSpeed = .238f;
 		break;
 	case AVH_USER3_ALIEN_PLAYER1:
 		//theMoveSpeed = .04f;
-		theMoveSpeed = .14f;
+		//theMoveSpeed = .14f;
+		theMoveSpeed = .25f;
 		break;
 	case AVH_USER3_ALIEN_PLAYER2:
-		theMoveSpeed = .08f;
+		//theMoveSpeed = .08f;
+		theMoveSpeed = .2f;
 		break;
 	case AVH_USER3_ALIEN_PLAYER3:
-		theMoveSpeed = .11f;
+		//theMoveSpeed = .11f;
+		theMoveSpeed = .275f;
 		break;
 	case AVH_USER3_ALIEN_PLAYER4:
-		theMoveSpeed = .09f;
+		//theMoveSpeed = .09f;
+		theMoveSpeed = .225f;
 		break;
 	case AVH_USER3_ALIEN_PLAYER5:
-		theMoveSpeed = .09f;
+		//theMoveSpeed = .09f;
+		theMoveSpeed = .225f;
 		break;
 	}
 	

--- a/main/source/mod/AvHPlayer.cpp
+++ b/main/source/mod/AvHPlayer.cpp
@@ -7482,12 +7482,18 @@ void AvHPlayer::GetViewForUser3(AvHUser3 inUser3, bool inIsDucking, float& outFO
     {
     case AVH_USER3_NONE:
     case AVH_USER3_MARINE_PLAYER:
-    case AVH_USER3_COMMANDER_PLAYER:
-    case AVH_USER3_ALIEN_PLAYER4:
-    default:
-        outFOV    = 90;
-        outOffset = inIsDucking ? kDuckingViewHeightPercentage*HULL1_MAXZ: kStandingViewHeightPercentage*HULL0_MAXZ;
-        break;
+	//case AVH_USER3_COMMANDER_PLAYER:
+	case AVH_USER3_ALIEN_PLAYER4:
+	default:
+		outFOV = 90;
+		outOffset = inIsDucking ? kDuckingViewHeightPercentage * HULL1_MAXZ : kStandingViewHeightPercentage * HULL0_MAXZ;
+		break;
+
+	//commander fov upped from 90 to prevent borders of black map background not drawing, compensated in hud_update
+	case AVH_USER3_COMMANDER_PLAYER:
+		outFOV = 106;
+		outOffset = inIsDucking ? kDuckingViewHeightPercentage * HULL1_MAXZ : kStandingViewHeightPercentage * HULL0_MAXZ;
+		break;
 
     case AVH_USER3_ALIEN_PLAYER1:
         outFOV    = 105;

--- a/main/source/pm_shared/pm_shared.cpp
+++ b/main/source/pm_shared/pm_shared.cpp
@@ -6356,8 +6356,12 @@ void PM_Jetpack()
 
             float theWeightScalar = kBaseScalar + (1.0f - kBaseScalar)*((pmove->clientmaxspeed - theMinMarineSpeed)/(theMaxMarineSpeed - theMinMarineSpeed));
             
-            pmove->velocity[0] += (theWishVelocity[0]/pmove->clientmaxspeed)*kJetpackLateralScalar;
-            pmove->velocity[1] += (theWishVelocity[1]/pmove->clientmaxspeed)*kJetpackLateralScalar;
+			// Old lateral jetpack code - acceleration scales with framerate
+			//pmove->velocity[0] += (theWishVelocity[0]/pmove->clientmaxspeed)*kJetpackLateralScalar;
+			//pmove->velocity[1] += (theWishVelocity[1]/pmove->clientmaxspeed)*kJetpackLateralScalar;
+
+			pmove->velocity[0] += (theWishVelocity[0] / pmove->clientmaxspeed) * (theTimePassed * theWeightScalar*kJetpackForce);
+			pmove->velocity[1] += (theWishVelocity[1] / pmove->clientmaxspeed) * (theTimePassed * theWeightScalar*kJetpackForce);
             pmove->velocity[2] += theTimePassed*theWeightScalar*kJetpackForce;
 
             // Play an event every so often


### PR DESCRIPTION
- Jetpack thrust changed to be FPS independent and modeled after previous 100fps movement.
- Hor+ widescreen with workaround for commander view not drawing black map background outside of the intended fov. Clamping included to balance gameplay.
- Walk speeds changed as workaround for bug that caused them to lower.