### PR TITLE
added cl_widescreen and fix for commander item placement and background

### DIFF
--- a/main/source/cl_dll/chud.h
+++ b/main/source/cl_dll/chud.h
@@ -22,6 +22,7 @@ public:
 	HSPRITE						m_hsprCursor;
 	float m_flTime;	   // the current client time
 	float m_fOldTime;  // the time at which the HUD was last redrawn
+	float m_wsFOV; //fov recalc corrected for widescreen
 	double m_flTimeDelta; // the difference between flTime and fOldTime
 	Vector	m_vecOrigin;
 	Vector	m_vecAngles;

--- a/main/source/cl_dll/hud_update.cpp
+++ b/main/source/cl_dll/hud_update.cpp
@@ -47,52 +47,36 @@ int CHud::UpdateClientData(client_data_t *cdata, float time)
 	float height = ScreenHeight();
 
 	//horizontal+ widescreen view correction - engine uses vertical-
-	//starts with hacked in commander view fix where commander fov was changed to 106 so the black background beind the map is fully rendered - remove that section and change comm fov back to 90 if fixed
-	if (gHUD.GetIsInTopDownMode())
+	bool wstoggle = CVAR_GET_FLOAT("cl_widescreen") != 0;
+	if (wstoggle)
 	{
-		float commFOV;
+			m_wsFOV = atanf(tan(m_iFOV * M_PI / 360) * 0.75 * width / height) * 360 / M_PI;
 
-		commFOV = atanf(tan(m_iFOV * M_PI / 360) * 0.5625 * width / height) * 360 / M_PI;
-
-		//clamp
-		if (commFOV > 107)
-		{
-			commFOV = 106;
-		}
-		else if (commFOV < 90)
-		{
-			commFOV = 90;
-		}
-
-		cdata->fov = commFOV;
+			//clamp for game balance
+			if (m_iFOV == 105 && m_wsFOV > 121)
+			{
+				m_wsFOV = 120;
+			}
+			else if (m_iFOV == 100 && m_wsFOV > 117)
+			{
+				m_wsFOV = 116;
+			}
+			else if (m_iFOV == 90 && m_wsFOV > 107)
+			{
+				m_wsFOV = 106;
+			}
+			else if (m_wsFOV < 90)
+			{
+				m_wsFOV = 90;
+			}
 	}
 	else
 	{
-		float newFOV;
-
-		newFOV = atanf(tan(m_iFOV * M_PI / 360) * 0.75 * width / height) * 360 / M_PI;
-
-		//clamp for game balance
-		if (m_iFOV == 105 && newFOV > 121)
-		{
-			newFOV = 120;
-		}
-		else if (m_iFOV == 100 && newFOV > 117)
-		{
-			newFOV = 116;
-		}
-		else if (m_iFOV == 90 && newFOV > 107)
-		{
-			newFOV = 106;
-		}
-		else if (newFOV < 90)
-		{
-			newFOV = 90;
-		}
-
-		cdata->fov = newFOV;
+		m_wsFOV = m_iFOV;
 	}
-	
+
+	cdata->fov = m_wsFOV;
+
 	CL_ResetButtonBits( m_iKeyBits );
 
 	// return 1 if in anything in the client_data struct has been changed, 0 otherwise

--- a/main/source/cl_dll/input.cpp
+++ b/main/source/cl_dll/input.cpp
@@ -137,6 +137,7 @@ cvar_t	*cl_forcedefaultfov;
 cvar_t	*cl_dynamiclights;
 cvar_t	*cl_buildmessages;
 cvar_t	*cl_particleinfo;
+cvar_t	*cl_widescreen;
 
 /*
 ===============================================================================
@@ -1544,6 +1545,7 @@ void InitInput (void)
 	cl_cmhotkeys		= gEngfuncs.pfnRegisterVariable ( kvCMHotkeys, "qwerasdfzxcv", FCVAR_ARCHIVE );
 	cl_forcedefaultfov	= gEngfuncs.pfnRegisterVariable ( kvForceDefaultFOV, "0", FCVAR_ARCHIVE );
 	cl_particleinfo		= gEngfuncs.pfnRegisterVariable ( kvParticleInfo, "0", FCVAR_ARCHIVE );
+	cl_widescreen		= gEngfuncs.pfnRegisterVariable	( kvWidescreen, "1", FCVAR_ARCHIVE );
 
 	// Initialize third person camera controls.
 	CAM_Init();

--- a/main/source/cl_dll/util.cpp
+++ b/main/source/cl_dll/util.cpp
@@ -177,7 +177,7 @@ void CreatePickingRay( int mousex, int mousey, Vector& outVecPickingRay )
 
 //	char gDebugMessage[256];
 
-	float fovDegrees = gHUD.m_iFOV;
+	float fovDegrees = gHUD.m_wsFOV;
 
 	//cl_entity_s* theLocalEntity = gEngfuncs.GetLocalPlayer();
 	//Vector vecRenderOrigin = theLocalEntity->origin;

--- a/main/source/mod/AvHClientVariables.h
+++ b/main/source/mod/AvHClientVariables.h
@@ -47,6 +47,7 @@ extern cvar_t*	cl_musicdir;
 // :
 #define	kvCMHotKeys			"cl_cmhotkeys"
 #define	kvForceDefaultFOV	"cl_forcedefaultfov"
+#define	kvWidescreen		"cl_widescreen"
 #define kvCenterEntityID	"cl_centerentityid"
 #define kvHighDetail		"cl_highdetail"
 #define kvCMHotkeys			"cl_cmhotkeys"

--- a/main/source/mod/AvHPlayer.cpp
+++ b/main/source/mod/AvHPlayer.cpp
@@ -7482,16 +7482,10 @@ void AvHPlayer::GetViewForUser3(AvHUser3 inUser3, bool inIsDucking, float& outFO
     {
     case AVH_USER3_NONE:
     case AVH_USER3_MARINE_PLAYER:
-	//case AVH_USER3_COMMANDER_PLAYER:
+	case AVH_USER3_COMMANDER_PLAYER:
 	case AVH_USER3_ALIEN_PLAYER4:
 	default:
 		outFOV = 90;
-		outOffset = inIsDucking ? kDuckingViewHeightPercentage * HULL1_MAXZ : kStandingViewHeightPercentage * HULL0_MAXZ;
-		break;
-
-	//commander fov upped from 90 to prevent borders of black map background not drawing, compensated in hud_update
-	case AVH_USER3_COMMANDER_PLAYER:
-		outFOV = 106;
 		outOffset = inIsDucking ? kDuckingViewHeightPercentage * HULL1_MAXZ : kStandingViewHeightPercentage * HULL0_MAXZ;
 		break;
 


### PR DESCRIPTION
cl_widescreen is a legacy widescreen toggle. Its default is 1 and allows horizontal+ widescreen correction; setting to 0 switches to vertical-.  It can be revisited in the future if zoom scripting with it is an issue.  Its use when in a 4:3 resolution has no affect.

This commit also fixes item placement as a commander not working correctly in non 16:9 aspect ratios.