### PR TITLE
Changes/fixes to r_dynamic, cl_ambientsound, skulk walk speed, -attack

### DIFF
--- a/main/source/cl_dll/input.cpp
+++ b/main/source/cl_dll/input.cpp
@@ -135,6 +135,7 @@ cvar_t	*cl_highdetail;
 cvar_t	*cl_cmhotkeys;
 cvar_t	*cl_forcedefaultfov;
 cvar_t	*cl_dynamiclights;
+cvar_t	*r_dynamic;
 cvar_t	*cl_buildmessages;
 cvar_t	*cl_particleinfo;
 cvar_t	*cl_widescreen;
@@ -779,7 +780,7 @@ void IN_AttackUp(void)
 {
 	KeyUp( &in_attack );
 	in_cancel = 0;
-	IN_Attack2Up();
+	//IN_Attack2Up();
 }
 
 void IN_AttackDownForced(void)

--- a/main/source/cl_dll/input.cpp
+++ b/main/source/cl_dll/input.cpp
@@ -1551,7 +1551,7 @@ void InitInput (void)
 	cl_forcedefaultfov	= gEngfuncs.pfnRegisterVariable ( kvForceDefaultFOV, "0", FCVAR_ARCHIVE );
 	cl_particleinfo		= gEngfuncs.pfnRegisterVariable ( kvParticleInfo, "0", FCVAR_ARCHIVE );
 	cl_widescreen		= gEngfuncs.pfnRegisterVariable	( kvWidescreen, "1", FCVAR_ARCHIVE );
-	cl_ambientsound		= gEngfuncs.pfnRegisterVariable	( kvAmbientSound, "2", FCVAR_ARCHIVE);
+	cl_ambientsound		= gEngfuncs.pfnRegisterVariable	( kvAmbientSound, "0", FCVAR_ARCHIVE);
 	senslock			= gEngfuncs.pfnRegisterVariable	("senslock", "0", FCVAR_ARCHIVE);
 	hud_style			= gEngfuncs.pfnRegisterVariable	("hud_style", "1", FCVAR_ARCHIVE);
 	cl_chatbeep			= gEngfuncs.pfnRegisterVariable	("cl_chatbeep", "1", FCVAR_ARCHIVE);

--- a/main/source/dlls/sound.cpp
+++ b/main/source/dlls/sound.cpp
@@ -240,17 +240,8 @@ void CAmbientGeneric :: Precache( void )
 	}
 	if ( m_fActive )
 	{
-		
-		if (CVAR_GET_FLOAT("cl_ambientsound") == 0.0f)
-		{
-			UTIL_EmitAmbientSound(ENT(pev), pev->origin, szSoundFile,
-				0, m_flAttenuation, SND_SPAWNING, m_dpv.pitch);
-		}
-		else if (CVAR_GET_FLOAT("cl_ambientsound") == 2.0f)
-		{
-			UTIL_EmitAmbientSound(ENT(pev), pev->origin, szSoundFile,
-				(m_dpv.vol * 0.01), m_flAttenuation, SND_SPAWNING, m_dpv.pitch);
-		}
+		UTIL_EmitAmbientSound(ENT(pev), pev->origin, szSoundFile,
+			(m_dpv.vol * 0.01), m_flAttenuation, SND_SPAWNING, m_dpv.pitch);
 
 		pev->nextthink = gpGlobals->time + 0.1;
 	}
@@ -442,18 +433,8 @@ void CAmbientGeneric :: RampThink( void )
 		if (pitch == PITCH_NORM)
 			pitch = PITCH_NORM + 1; // don't send 'no pitch' !
 
-		//bool ambtoggle = CVAR_GET_FLOAT("cl_ambientsound") == 0.0f;
-		if (CVAR_GET_FLOAT("cl_ambientsound") == 0.0f)
-		{
-			UTIL_EmitAmbientSound(ENT(pev), pev->origin, szSoundFile,
-				0, m_flAttenuation, flags, pitch);
-		}
-		else if (CVAR_GET_FLOAT("cl_ambientsound") == 2.0f)
-		{
-			UTIL_EmitAmbientSound(ENT(pev), pev->origin, szSoundFile,
-				(vol * 0.01), m_flAttenuation, flags, pitch);
-		}
-
+		UTIL_EmitAmbientSound(ENT(pev), pev->origin, szSoundFile,
+			(vol * 0.01), m_flAttenuation, flags, pitch);
 	}
 
 	// update ramps at 5hz
@@ -650,17 +631,8 @@ void CAmbientGeneric :: ToggleUse ( CBaseEntity *pActivator, CBaseEntity *pCalle
 
 		InitModulationParms();
 
-		//bool ambtoggle = CVAR_GET_FLOAT("cl_ambientsound") == 0.0f;
-		if (CVAR_GET_FLOAT("cl_ambientsound") == 0.0f)
-		{
-			UTIL_EmitAmbientSound(ENT(pev), pev->origin, szSoundFile,
-				0, m_flAttenuation, 0, m_dpv.pitch);
-		}
-		else if (CVAR_GET_FLOAT("cl_ambientsound") == 2.0f)
-		{
-			UTIL_EmitAmbientSound(ENT(pev), pev->origin, szSoundFile,
-				(m_dpv.vol * 0.01), m_flAttenuation, 0, m_dpv.pitch);
-		}
+		UTIL_EmitAmbientSound(ENT(pev), pev->origin, szSoundFile,
+			(m_dpv.vol * 0.01), m_flAttenuation, 0, m_dpv.pitch);
 		
 		pev->nextthink = gpGlobals->time + 0.1;
 

--- a/main/source/mod/AvHAmbientSound.cpp
+++ b/main/source/mod/AvHAmbientSound.cpp
@@ -101,7 +101,14 @@ void AvHAmbientSound::UpdateVolume(const Vector& inListenerPosition)
 		theVolume = this->mVolume - this->mVolume*(theDistance/(float)this->mFadeDistance);
 	}
 
-	theVolume = min(max(0, theVolume), 255);
+		if (CVAR_GET_FLOAT("cl_ambientsound") != 1.0f)
+		{
+			theVolume = 0;
+		}
+		else
+		{
+			theVolume = min(max(0, theVolume), 255);
+		}
 
         FMOD_INSTANCE* theFMOD = gHUD.GetFMOD();
 

--- a/main/source/mod/AvHEntities.cpp
+++ b/main/source/mod/AvHEntities.cpp
@@ -687,15 +687,7 @@ void AvHNoBuild::Spawn()
 AvHMP3Audio::AvHMP3Audio()
 {
 	this->mUseState = false;
-	//bool ambtoggle = CVAR_GET_FLOAT("cl_ambientsound") != 1;
-	//if (ambtoggle)
-	//{
-	//	this->mSoundVolume = 0;
-	//}
-	//else
-	//{
-		this->mSoundVolume = 255;
-//	}
+	this->mSoundVolume = 255;
 	this->mLooping = false;
 }
 
@@ -713,16 +705,7 @@ void AvHMP3Audio::KeyValue( KeyValueData* pkvd )
 	}
 	else if(FStrEq(pkvd->szKeyName, "soundvolume"))
 	{
-		bool ambtoggle = CVAR_GET_FLOAT("cl_ambientsound") != 1;
-		if (ambtoggle)
-		{
-			this->mSoundVolume = 0;
-		}
-		else
-		{
-			this->mSoundVolume = atoi(pkvd->szValue);
-		}
-		
+		this->mSoundVolume = atoi(pkvd->szValue);
 		pkvd->fHandled = TRUE;
 	}
 	else if(FStrEq(pkvd->szKeyName, "fadedistance"))

--- a/main/source/mod/AvHMovementUtil.cpp
+++ b/main/source/mod/AvHMovementUtil.cpp
@@ -270,7 +270,7 @@ float AvHMUGetWalkSpeedFactor(AvHUser3 inUser3)
 	case AVH_USER3_ALIEN_PLAYER1:
 		//theMoveSpeed = .04f;
 		//theMoveSpeed = .14f;
-		theMoveSpeed = .25f;
+		theMoveSpeed = .35f;
 		break;
 	case AVH_USER3_ALIEN_PLAYER2:
 		//theMoveSpeed = .08f;


### PR DESCRIPTION
- r_dynamic is now client toggleable for non-nvidia graphics users experiencing performance issues
- cl_ambientsound changed to be client side. It previously changed some code on the server, causing ambient sounds to be off for all users on dedicated servers. Unfortunately, there is no way I can find to toggle .wav map ambient sounds via a client only cvar. This command toggles mp3 sounds which are generally the most annoying and offensive. Players that wish to remove all ambient sound will need to replace the offending .wavs with blank files as was in previous versions of the game.
- Skulk walk speed changed to give the skulk 140ups when slow walking as it was in v3.2 and earlier.  It was mistakenly set to be too slow when those values were changed to address https://github.com/ENSL/NS/issues/68
- Releasing the attack bind should no longer cancel +movement