### PR TITLE
V33b2

### DIFF
--- a/main/source/dlls/client.cpp
+++ b/main/source/dlls/client.cpp
@@ -978,7 +978,6 @@ void ClientPrecache( void )
 	PRECACHE_UNMODIFIED_SOUND(kWingFlapSound3);
 	PRECACHE_UNMODIFIED_SOUND(kSiegeHitSound1);
 	PRECACHE_UNMODIFIED_SOUND(kSiegeHitSound2);
-	PRECACHE_UNMODIFIED_SOUND("misc/egg_idle.wav");
 	
 	// setup precaches always needed
 	PRECACHE_UNMODIFIED_SOUND("player/sprayer.wav");			// spray paint sound for PreAlpha

--- a/main/source/dlls/weapons.cpp
+++ b/main/source/dlls/weapons.cpp
@@ -800,7 +800,7 @@ void CBasePlayerItem::FallThink ( void )
 		pev->fuser4 = 0;
 	}
 	//weapons in air for too long from collision issues with other entities change to SOLID_TRIGGER to fall to ground
-	if ((pev->fuser4 > 0.7))
+	else if ((pev->fuser4 > 0.7))
 	{
 		pev->solid = SOLID_TRIGGER;
 		pev->fuser4 = 0;
@@ -928,14 +928,14 @@ void CBasePlayerItem::DefaultTouch( CBaseEntity *pOther )
 
 	SUB_UseTargets( pOther, USE_TOGGLE, 0 ); // UNDONE: when should this happen?
 
-	// Haven't had the crash but adding this in case due to weapons being able to turn to SOLID_TRIGGER before touching the ground with 2021 weapon collision fix.
-	// https://github.com/ValveSoftware/halflife/pull/1599
-	// If the item is falling and its Think remains FallItem after the player picks it up,
-	// then after the item touches the ground its Touch will be set back to DefaultTouch,
-	// so the player will pick it up again, this time Kill-ing the item (since we already have it in the inventory),
-	// which will make the pointer bad and crash the game.
-	if (m_pfnThink == &CBasePlayerItem::FallThink)
-		SetThink(NULL);
+	//// 2021 - Possible fix if crashes occur. Disabled because weapons can't be picked up if aliens touch them while they're falling.
+	//// https://github.com/ValveSoftware/halflife/pull/1599
+	//// If the item is falling and its Think remains FallItem after the player picks it up,
+	//// then after the item touches the ground its Touch will be set back to DefaultTouch,
+	//// so the player will pick it up again, this time Kill-ing the item (since we already have it in the inventory),
+	//// which will make the pointer bad and crash the game.
+	//if (m_pfnThink == &CBasePlayerItem::FallThink)
+		//SetThink(NULL);
 }
 
 BOOL CanAttack( float attack_time, float curtime, BOOL isPredicted )

--- a/main/source/mod/AvHPlayer.cpp
+++ b/main/source/mod/AvHPlayer.cpp
@@ -10074,9 +10074,11 @@ void AvHPlayer::UpdateTechNodes()
             }
 
 			if (UpdatedCosts && !theGameStarted)
+			{
+				theTechNodes.processBalanceChange();
 				UpdatedCosts = false;
-
-			if (theGameStarted && !UpdatedCosts)
+			}
+			else if (theGameStarted && !UpdatedCosts)
 			{
 				theTechNodes.processBalanceChange();
 				UpdatedCosts = true;

--- a/main/source/pm_shared/pm_shared.cpp
+++ b/main/source/pm_shared/pm_shared.cpp
@@ -6409,10 +6409,6 @@ void PM_Jetpack()
 			}
 			else
 			{
-				//pmove->velocity[0] += (theWishVelocity[0] / pmove->clientmaxspeed) * (theTimePassed * theWeightScalar*kJetpackForce);
-				//pmove->velocity[1] += (theWishVelocity[1] / pmove->clientmaxspeed) * (theTimePassed * theWeightScalar*kJetpackForce);
-				//pmove->velocity[2] += theTimePassed*theWeightScalar*kJetpackForce;
-
 				pmove->velocity[0] += (theWishVelocity[0] / pmove->clientmaxspeed) * (theTimePassed * kJetpackForce);
 				pmove->velocity[1] += (theWishVelocity[1] / pmove->clientmaxspeed) * (theTimePassed * kJetpackForce);
 				pmove->velocity[2] += theTimePassed*theWeightScalar*kJetpackForce;

--- a/main/source/pm_shared/pm_shared.cpp
+++ b/main/source/pm_shared/pm_shared.cpp
@@ -6389,6 +6389,7 @@ void PM_Jetpack()
             }
 
             float theWeightScalar = kBaseScalar + (1.0f - kBaseScalar)*((pmove->clientmaxspeed - theMinMarineSpeed)/(theMaxMarineSpeed - theMinMarineSpeed));
+			ALERT(at_console, "weightscalar = %f wishvel0= %f wishvel1= %f", theWeightScalar, theWishVelocity[0], theWishVelocity[1]);
             
 			// Old lateral jetpack code - acceleration scales with framerate
 			//pmove->velocity[0] += (theWishVelocity[0]/pmove->clientmaxspeed)*kJetpackLateralScalar;
@@ -6396,8 +6397,8 @@ void PM_Jetpack()
 
 			if (fastjp)
 			{
-				pmove->velocity[0] += (theWishVelocity[0] / pmove->clientmaxspeed) * (theTimePassed * theWeightScalar * 1562.5f);
-				pmove->velocity[1] += (theWishVelocity[1] / pmove->clientmaxspeed) * (theTimePassed * theWeightScalar * 1562.5f);
+				pmove->velocity[0] += ((theWishVelocity[0] / pmove->clientmaxspeed) * (theTimePassed * kJetpackForce) * 1.25f);
+				pmove->velocity[1] += ((theWishVelocity[1] / pmove->clientmaxspeed) * (theTimePassed * kJetpackForce) * 1.25f);
 				pmove->velocity[2] += theTimePassed * theWeightScalar*kJetpackForce;
 			}
 			else if (!newjp)
@@ -6408,8 +6409,12 @@ void PM_Jetpack()
 			}
 			else
 			{
-				pmove->velocity[0] += (theWishVelocity[0] / pmove->clientmaxspeed) * (theTimePassed * theWeightScalar*kJetpackForce);
-				pmove->velocity[1] += (theWishVelocity[1] / pmove->clientmaxspeed) * (theTimePassed * theWeightScalar*kJetpackForce);
+				//pmove->velocity[0] += (theWishVelocity[0] / pmove->clientmaxspeed) * (theTimePassed * theWeightScalar*kJetpackForce);
+				//pmove->velocity[1] += (theWishVelocity[1] / pmove->clientmaxspeed) * (theTimePassed * theWeightScalar*kJetpackForce);
+				//pmove->velocity[2] += theTimePassed*theWeightScalar*kJetpackForce;
+
+				pmove->velocity[0] += (theWishVelocity[0] / pmove->clientmaxspeed) * (theTimePassed * kJetpackForce);
+				pmove->velocity[1] += (theWishVelocity[1] / pmove->clientmaxspeed) * (theTimePassed * kJetpackForce);
 				pmove->velocity[2] += theTimePassed*theWeightScalar*kJetpackForce;
 			}
 

--- a/main/source/util/Balance.txt
+++ b/main/source/util/Balance.txt
@@ -121,7 +121,7 @@
 #define kGameHDSpaceNeeded 300
 #define kGameVersionMajor 3
 #define kGameVersionMinor 3
-#define kGameVersionRevision 1
+#define kGameVersionRevision 2
 #define kGestateBaseArmor 150
 #define kGestateHealth 200
 #define kGorgeArmorUpgrade 50


### PR DESCRIPTION
- Fixed guns not being able to be picked up and never decaying.
- Fixed jetpack lateral acceleration having its weight scaled twice since 3.2.1b. It's now a bit quicker to accelerate with extra equipment (ex. advanced weapons, ammo, welder, mines).
- Fixed popupmenu lifeform cost visuals not adjusting after the 1st round.
- Removed duplicate consistency check