### PR TITLE
NS v3.3b3

### DIFF
--- a/main/source/cl_dll/hud_crosshairs.cpp
+++ b/main/source/cl_dll/hud_crosshairs.cpp
@@ -17,13 +17,20 @@ int CHudCrosshairs::Init()
 	cl_cross_size = CVAR_CREATE("cl_cross_size", "6", FCVAR_ARCHIVE);
 	cl_cross_gap = CVAR_CREATE("cl_cross_gap", "3", FCVAR_ARCHIVE);
 	cl_cross_outline = CVAR_CREATE("cl_cross_outline", "2", FCVAR_ARCHIVE);
-	cl_cross_outline_alpha = CVAR_CREATE("cl_cross_outline_alpha", "255", FCVAR_ARCHIVE);
+	cl_cross_outline_alpha = CVAR_CREATE("cl_cross_outline_alpha", "", FCVAR_ARCHIVE);
 	cl_cross_outline_inner = CVAR_CREATE("cl_cross_outline_inner", "0", FCVAR_ARCHIVE);
 	cl_cross_circle_radius = CVAR_CREATE("cl_cross_circle_radius", "0", FCVAR_ARCHIVE);
+	cl_cross_circle_color = CVAR_CREATE("cl_cross_circle_color", "", FCVAR_ARCHIVE);
 	cl_cross_circle_thickness = CVAR_CREATE("cl_cross_circle_thickness", "1", FCVAR_ARCHIVE);
+	cl_cross_circle_alpha = CVAR_CREATE("cl_cross_circle_alpha", "", FCVAR_ARCHIVE);
+	cl_cross_circle_outline = CVAR_CREATE("cl_cross_circle_outline", "", FCVAR_ARCHIVE);
+	cl_cross_circle_outline_alpha = CVAR_CREATE("cl_cross_circle_outline_alpha", "", FCVAR_ARCHIVE);
+	cl_cross_circle_outline_inner = CVAR_CREATE("cl_cross_circle_outline_inner", "", FCVAR_ARCHIVE);
 	cl_cross_dot_size = CVAR_CREATE("cl_cross_dot_size", "0", FCVAR_ARCHIVE);
 	cl_cross_dot_color = CVAR_CREATE("cl_cross_dot_color", "", FCVAR_ARCHIVE);
+	cl_cross_dot_alpha = CVAR_CREATE("cl_cross_dot_alpha", "", FCVAR_ARCHIVE);
 	cl_cross_dot_outline = CVAR_CREATE("cl_cross_dot_outline", "0", FCVAR_ARCHIVE);
+	cl_cross_dot_outline_alpha = CVAR_CREATE("cl_cross_dot_outline_alpha", "", FCVAR_ARCHIVE);
 	cl_cross_line_top = CVAR_CREATE("cl_cross_line_top", "1", FCVAR_ARCHIVE);
 	cl_cross_line_bottom = CVAR_CREATE("cl_cross_line_bottom", "1", FCVAR_ARCHIVE);
 	cl_cross_line_left = CVAR_CREATE("cl_cross_line_left", "1", FCVAR_ARCHIVE);
@@ -53,14 +60,6 @@ int CHudCrosshairs::Draw(float time)
 	if (gHUD.GetInTopDownMode())
 		return 0;
 
-	// outline alpha perhaps unnecessary since odd numbered thicknesses feather the outline edges
-	unsigned char outalpha;
-	if (sscanf(cl_cross_outline_alpha->string, "%hhu", &outalpha) != 1)
-		outalpha = 255;
-	
-	if (outalpha == 0)
-		return 0;
-
 	unsigned char r, g, b;
 	if (sscanf(cl_cross_color->string, "%hhu %hhu %hhu", &r, &g, &b) != 3) {
 		r = 0;
@@ -80,7 +79,10 @@ int CHudCrosshairs::Draw(float time)
 	// Example below is for bottom line. Would also cause certain crosshairs that have outlines on invisible cross lines to not look right.
 	// gl.rectangle(Vector2D(center.x + offset, center.y + gap - half_width), Vector2D(center.x - offset, center.y + gap + size + half_width));
 	if (cl_cross_outline->value > 0.0f) {
-		//gl.color(0, 0, 0, alpha);
+		unsigned char outalpha;
+		if (sscanf(cl_cross_outline_alpha->string, "%hhu", &outalpha) != 1)
+			outalpha = alpha;
+
 		gl.color(0, 0, 0, outalpha);
 		gl.line_width(cl_cross_outline->value);
 
@@ -153,41 +155,62 @@ int CHudCrosshairs::Draw(float time)
 				gl.line(Vector2D(center.x + gap + half_width, center.y - half_thickness), Vector2D(center.x + gap + size - half_width, center.y - half_thickness));
 			}
 		}
+	}
 
-		// Dot
-		if (cl_cross_dot_size->value > 0.0f && cl_cross_dot_outline->value > 0.0f) {
-			float size = cl_cross_dot_size->value;
-			Vector2D offset = Vector2D(size / 2.0f, size / 2.0f);
-			float dot_half_width = cl_cross_dot_outline->value / 2.0f;
+	unsigned char dotout;
+	if (sscanf(cl_cross_dot_outline->string, "%hhu", &dotout) != 1)
+		dotout = cl_cross_outline->value;
+	// Dot outline
+	if (cl_cross_dot_size->value > 0.0f && dotout > 0.0f) {
+		unsigned char dotoutalpha;
+		if (sscanf(cl_cross_circle_outline_alpha->string, "%hhu", &dotoutalpha) != 1)
+			dotoutalpha = alpha;
 
-			gl.line(Vector2D(center.x - offset.x - dot_half_width, center.y - offset.y), Vector2D(center.x + offset.x + dot_half_width, center.y - offset.y));
-			gl.line(Vector2D(center.x + offset.x, center.y - offset.y + dot_half_width), Vector2D(center.x + offset.x, center.y + offset.y - dot_half_width));
-			gl.line(Vector2D(center.x - offset.x, center.y - offset.y + dot_half_width), Vector2D(center.x - offset.x, center.y + offset.y - dot_half_width));
-			gl.line(Vector2D(center.x - offset.x - dot_half_width, center.y + offset.y), Vector2D(center.x + offset.x + dot_half_width, center.y + offset.y));
+		gl.color(0, 0, 0, dotoutalpha);
+
+		float size = cl_cross_dot_size->value;
+		Vector2D offset = Vector2D(size / 2.0f, size / 2.0f);
+		float dot_half_width = dotout / 2.0f;
+
+		gl.line(Vector2D(center.x - offset.x - dot_half_width, center.y - offset.y), Vector2D(center.x + offset.x + dot_half_width, center.y - offset.y));
+		gl.line(Vector2D(center.x + offset.x, center.y - offset.y + dot_half_width), Vector2D(center.x + offset.x, center.y + offset.y - dot_half_width));
+		gl.line(Vector2D(center.x - offset.x, center.y - offset.y + dot_half_width), Vector2D(center.x - offset.x, center.y + offset.y - dot_half_width));
+		gl.line(Vector2D(center.x - offset.x - dot_half_width, center.y + offset.y), Vector2D(center.x + offset.x + dot_half_width, center.y + offset.y));
+	}
+
+	unsigned char circleout;
+	if (sscanf(cl_cross_circle_outline->string, "%hhu", &circleout) != 1)
+		circleout = cl_cross_outline->value;
+	// Circle outline
+	if (cl_cross_circle_radius->value > 0.0f && cl_cross_circle_thickness->value > 0.0f && circleout > 0.0f) {
+
+		unsigned char circleoutalpha;
+		if (sscanf(cl_cross_circle_outline_alpha->string, "%hhu", &circleoutalpha) != 1)
+			circleoutalpha = alpha;
+		unsigned char circleoutinner;
+		if (sscanf(cl_cross_circle_outline_inner->string, "%hhu", &circleoutinner) != 1)
+			circleoutinner = cl_cross_outline_inner->value;
+
+		gl.color(0, 0, 0, circleoutalpha);
+
+		auto radius = cl_cross_circle_radius->value;
+
+		if (circleoutinner == 0.0f)
+		{
+			radius += (cl_cross_circle_thickness->value * 0.5f) + (circleout * 0.5f);
+			gl.line_width(circleout);
+		}
+		else
+		{
+			gl.line_width(cl_cross_circle_thickness->value + circleout);
 		}
 
-		// Circle
-		if (cl_cross_circle_radius->value > 0.0f && cl_cross_circle_thickness->value > 0.0f) {
-
-			auto radius = cl_cross_circle_radius->value;
-
-			if (cl_cross_outline_inner->value == 0.0f)
-			{
-				radius += (cl_cross_circle_thickness->value * 0.5f) + (cl_cross_outline->value * 0.5f);
-				gl.line_width(cl_cross_outline->value);
-			}
-			else
-			{
-				gl.line_width(cl_cross_circle_thickness->value + cl_cross_outline->value);
-			}
-
-			if (old_circle_radius != radius) {
-				// Recompute the circle points.
-				circle_points = HudGL::compute_circle(radius);
-				old_circle_radius = radius;
-			}
-			gl.circle(center, circle_points);
+		if (old_circle_radius != radius) {
+			// Recompute the circle points.
+			circle_points = HudGL::compute_circle(radius);
+			old_circle_radius = radius;
 		}
+		gl.circle(center, circle_points);
 	}
 
 	gl.color(r, g, b, alpha);
@@ -209,12 +232,23 @@ int CHudCrosshairs::Draw(float time)
 			gl.line(Vector2D(center.x + gap + size, center.y), Vector2D(center.x + gap, center.y));
 	}
 
-//#ifdef __APPLE__
-//	//Remove when OSX builds with c++11
-//#else
 	// Draw the circle.
-	if (cl_cross_circle_radius->value > 0.0f) {
-		gl.line_width(1.0f);
+	if (cl_cross_circle_radius->value > 0.0f && cl_cross_circle_thickness->value > 0.0f) {
+		unsigned char circlealpha;
+		if (sscanf(cl_cross_circle_alpha->string, "%hhu", &circlealpha) != 1)
+			circlealpha = alpha;
+
+		unsigned char circr, circg, circb;
+		if (sscanf(cl_cross_circle_color->string, "%hhu %hhu %hhu", &circr, &circg, &circb) == 3)
+		{
+			gl.color(circr, circg, circb, circlealpha);
+		}
+		else
+		{
+			gl.color(r, g, b, circlealpha);
+		}
+		
+		gl.line_width(cl_cross_circle_thickness->value);
 
 		float radius = cl_cross_circle_radius->value;
 		if (old_circle_radius != radius) {
@@ -225,13 +259,22 @@ int CHudCrosshairs::Draw(float time)
 
 		gl.circle(center, circle_points);
 	}
-//#endif
 
 	// Draw the dot.
 	if (cl_cross_dot_size->value > 0.0f) {
-		unsigned char r, g, b;
-		if (sscanf(cl_cross_dot_color->string, "%hhu %hhu %hhu", &r, &g, &b) == 3)
-			gl.color(r, g, b, alpha);
+		unsigned char dotalpha;
+		if (sscanf(cl_cross_dot_alpha->string, "%hhu", &dotalpha) != 1)
+			dotalpha = alpha;
+
+		unsigned char dotr, dotg, dotb;
+		if (sscanf(cl_cross_dot_color->string, "%hhu %hhu %hhu", &dotr, &dotg, &dotb) == 3)
+		{
+			gl.color(dotr, dotg, dotb, dotalpha);
+		}
+		else
+		{
+			gl.color(r, g, b, dotalpha);
+		}
 
 		float size = cl_cross_dot_size->value;
 		Vector2D offset = Vector2D(size / 2.0f, size / 2.0f);

--- a/main/source/cl_dll/hud_crosshairs.h
+++ b/main/source/cl_dll/hud_crosshairs.h
@@ -16,21 +16,24 @@ class CHudCrosshairs : public CHudBase
 	cvar_t* cl_cross_outline_alpha;
 	cvar_t* cl_cross_outline_inner;
 	cvar_t* cl_cross_circle_radius;
+	cvar_t* cl_cross_circle_color;
 	cvar_t* cl_cross_circle_thickness;
+	cvar_t* cl_cross_circle_alpha;
+	cvar_t* cl_cross_circle_outline;
+	cvar_t* cl_cross_circle_outline_alpha;
+	cvar_t* cl_cross_circle_outline_inner;
 	cvar_t* cl_cross_dot_size;
 	cvar_t* cl_cross_dot_color;
+	cvar_t* cl_cross_dot_alpha;
 	cvar_t* cl_cross_dot_outline;
+	cvar_t* cl_cross_dot_outline_alpha;
 	cvar_t* cl_cross_line_top;
 	cvar_t* cl_cross_line_bottom;
 	cvar_t* cl_cross_line_left;
 	cvar_t* cl_cross_line_right;
 
-//#ifdef __APPLE__
-//	//Remove when OSX builds with c++11
-//#else
 	float old_circle_radius;
 	std::vector<Vector2D> circle_points;
-//#endif
 
 public:
 	virtual int Init();

--- a/main/source/cl_dll/input.cpp
+++ b/main/source/cl_dll/input.cpp
@@ -805,7 +805,12 @@ void IN_AttackUp(void)
 {
 	KeyUp( &in_attack );
 	in_cancel = 0;
-	//IN_Attack2Up();
+	// Attack2up only for onos so it can end +attack onos charges.  Attack2up for all causes blink and leap to cancel if you release attack while blinking or leaping.
+	if (gViewPort)
+	{
+		if (gHUD.GetHUDUser3() == AVH_USER3_ALIEN_PLAYER5)
+			IN_Attack2Up();
+	}
 }
 
 void IN_AttackDownForced(void)

--- a/main/source/mod/AvHBasePlayerWeapon.cpp
+++ b/main/source/mod/AvHBasePlayerWeapon.cpp
@@ -266,14 +266,14 @@ BOOL AvHBasePlayerWeapon::DefaultReload( int iClipSize, int iAnim, float fDelay,
 		return TRUE;
 	// :
 
-	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0 || m_iId == AVH_WEAPON_KNIFE)
+	if (m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] <= 0)
 		return FALSE;
 
 	// Don't reload while we're resupplying
-	if(this->mTimeOfLastResupply > 0)
-	{
-		return FALSE;
-	}
+//	if(this->mTimeOfLastResupply > 0)
+//	{
+//		return FALSE;
+//	}
 
 	int j = min(iClipSize - m_iClip, m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType]);	
 	
@@ -283,14 +283,15 @@ BOOL AvHBasePlayerWeapon::DefaultReload( int iClipSize, int iAnim, float fDelay,
 	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + fDelay;
 	
 	//!!UNDONE -- reload sound goes here !!!
-	//SendWeaponAnim( iAnim, UseDecrement() ? 1 : 0 );
+	// 2021 Ammo networking. Uncommented to not send animations to the client that initiated the reload. This is HL SDK code.
+	SendWeaponAnim( iAnim, UseDecrement() ? 1 : 0 );
 	//// 2021 Ammo networking. Commented below - client was getting sent extra reload animations causing visual stutter.
 	//this->SendWeaponAnim(iAnim);
 
-	// Send reload to all players.  Reloads are initiated server-side, so send down to local client as well
 	//// 2021 Ammo networking. Commented below - client was getting sent extra reload animations causing visual stutter.
+	// Send reload to all players.  Reloads are initiated server-side, so send down to local client as well
 	//this->m_pPlayer->pev->weaponanim = iAnim;
-	this->PlaybackEvent(this->mWeaponAnimationEvent, iAnim, FEV_RELIABLE);
+	//this->PlaybackEvent(this->mWeaponAnimationEvent, iAnim, FEV_RELIABLE);
 
 	//ALERT(at_console, "defaultreload nextattack:%g\n", m_pPlayer->m_flNextAttack);
 	// Player model reload animation
@@ -1087,8 +1088,8 @@ bool AvHBasePlayerWeapon::Resupply()
 
         const float theDelay = 1.0f;
 		//bugfix - don't let resupply shorten reload time
-        this->m_pPlayer->m_flNextAttack = max(this->m_pPlayer->m_flNextAttack,UTIL_WeaponTimeBase() + theDelay);
-        this->mTimeOfLastResupply = UTIL_WeaponTimeBase() + theDelay;
+		this->m_pPlayer->m_flNextAttack = max(this->m_pPlayer->m_flNextAttack,UTIL_WeaponTimeBase() + theDelay);
+		this->mTimeOfLastResupply = UTIL_WeaponTimeBase() + theDelay;
 	}
 
 	return theResupplied;

--- a/main/source/mod/AvHEvents.cpp
+++ b/main/source/mod/AvHEvents.cpp
@@ -939,9 +939,9 @@ void EV_SonicGun(struct event_args_s* args)
 //		}
 		//EV_HLDM_FireBullets( idx, forward, right, up, kSGBulletsPerShot, vecSrc, vecAiming, kSGRange, BULLET_PLAYER_BUCKSHOT, 0, &tracerCount[idx-1], VECTOR_CONE_20DEGREES.x, VECTOR_CONE_20DEGREES.y);
 		
-		bool oldpellets = (gHUD.GetServerVariableFloat(kvVersion) < 323.0f || gHUD.GetServerVariableFloat(kvNewsgspread) == 0.0f);
+		bool newpellets = (gHUD.GetServerVariableFloat(kvVersion) > 322.0f || gHUD.GetServerVariableFloat(kvNewsgspread) != 0.0f);
 
-		if (oldpellets)
+		if (!newpellets)
 		{
 			EV_HLDM_FireBulletsPlayer(idx, forward, right, up, 10, vecSrc, vecAiming, kSGRange, BULLET_PLAYER_BUCKSHOT, 0, &tracerCount[idx - 1], kSGSpread, args->iparam1);
 		}

--- a/main/source/pm_shared/pm_shared.cpp
+++ b/main/source/pm_shared/pm_shared.cpp
@@ -6566,7 +6566,7 @@ void PM_PlayerMove ( qboolean server )
     NS_UpdateWallsticking();
 
     // Don't run ladder code if dead or on a train, or a lerk or a skulk
-    bool theIsFlyingAlien = (pmove->iuser3 == AVH_USER3_ALIEN_PLAYER3) && (pmove->onground == -1);
+    bool theIsLerk = (pmove->iuser3 == AVH_USER3_ALIEN_PLAYER3);
     bool theIsSkulk = (pmove->iuser3 == AVH_USER3_ALIEN_PLAYER1);
 
 //	if ( PM_GetIsBlinking() ) {
@@ -6574,7 +6574,7 @@ void PM_PlayerMove ( qboolean server )
 		g_onladder[pmove->player_index] = 0;
 	}
 	else {
-		if ( !pmove->dead && !(pmove->flags & FL_ONTRAIN) && !gIsJetpacking[pmove->player_index] && !GetHasUpgrade(pmove->iuser4, MASK_WALLSTICKING) && !theIsFlyingAlien && !theIsSkulk)
+		if ( !pmove->dead && !(pmove->flags & FL_ONTRAIN) && !gIsJetpacking[pmove->player_index] && !GetHasUpgrade(pmove->iuser4, MASK_WALLSTICKING) && !theIsLerk && !theIsSkulk)
 		{
 			pLadder = PM_Ladder();
 			if ( pLadder )

--- a/main/source/util/Balance.txt
+++ b/main/source/util/Balance.txt
@@ -121,7 +121,7 @@
 #define kGameHDSpaceNeeded 300
 #define kGameVersionMajor 3
 #define kGameVersionMinor 3
-#define kGameVersionRevision 2
+#define kGameVersionRevision 3
 #define kGestateBaseArmor 150
 #define kGestateHealth 200
 #define kGorgeArmorUpgrade 50

--- a/main/user.scr
+++ b/main/user.scr
@@ -48,7 +48,7 @@ DESCRIPTION INFO_OPTIONS
 		{ "0" }
 	}
 
-		"cl_ambientsound"
+	"cl_ambientsound"
 	{
 		"Ambient sound volume (0 to 1)"
 		{ NUMBER 0.000000 1.000000 }
@@ -93,6 +93,68 @@ DESCRIPTION INFO_OPTIONS
 			"Full Zoom (3X) " "3"
 		}
 		{ "3.000000" }
+	}
+		
+	"cl_mutemenu"
+	{
+		"Scoreboard mute menu hotkey"
+		{
+			LIST
+			"None" "0"
+			"Left click" "1"
+			"Right click" "2"
+			"Middle mouse" "3"
+		}
+		{ "3.000000" }
+	}
+
+	"zoom_sensitivity_ratio"
+	{
+		"Zoom sensitivity ratio (skulk/gorge)"
+		{ NUMBER 0.000000 5.000000 }
+		{ "1.000000" }
+	}
+
+	"senslock"
+	{
+		"Don't scale sensitivity with FOV (Skulk/Gorge)"
+		{ BOOL }
+		{ "0" }
+	}
+
+	"r_dynamic"
+	{
+		"Dynamic lighting (non-nvidia graphics users should turn off)"
+		{ BOOL }
+		{ "1" }
+	}
+
+	"cl_dynamiclights"
+	{
+		"Dynamic lights"
+		{ BOOL }
+		{ "0" }
+	}
+
+	"cl_showspeed"
+	{
+		"Show player speed"
+		{ BOOL }
+		{ "0" }
+	}
+	
+	"hud_fastswitch"
+	{
+		"Weapon fast-switch"
+		{ BOOL }
+		{ "1" }
+	}
+	
+	"cl_cmhotkeys"
+	{
+		"Commander hotkeys"
+		{ STRING }
+		{ "qwerasdfzxcv" }
 	}
 
 	"cl_cross"
@@ -147,8 +209,8 @@ DESCRIPTION INFO_OPTIONS
 	"cl_cross_outline_alpha"
 	{
 		"Crosshair outline transparency (0-255)"
-		{ NUMBER 0.000000 255.000000 }
-		{ "255.000000" }
+		{ STRING }
+		{ "" }
 	}
 
 	"cl_cross_outline_inner"
@@ -158,32 +220,116 @@ DESCRIPTION INFO_OPTIONS
 		{ "0" }
 	}
 
+		"cl_cross_line_top"
+	{
+		"Cross top line"
+		{ BOOL }
+		{ "1" }
+	}
+
+	"cl_cross_line_bottom"
+	{
+		"Cross bottom line"
+		{ BOOL }
+		{ "1" }
+	}
+
+		"cl_cross_line_left"
+	{
+		"Cross left line"
+		{ BOOL }
+		{ "1" }
+	}
+
+		"cl_cross_line_right"
+	{
+		"Cross right line"
+		{ BOOL }
+		{ "1" }
+	}
+
 	"cl_cross_dot_size"
 	{
-		"Crosshair dot size"
+		"Dot size"
 		{ NUMBER -1.000000 -1.000000 }
-		{ "0.000000" }
+		{ "0" }
+	}
+
+	"cl_cross_dot_color"
+	{
+		"Dot color (R G B)"
+		{ STRING }
+		{ "" }
+	}
+
+	"cl_cross_dot_alpha"
+	{
+		"Dot transparency (0-255)"
+		{ STRING }
+		{ "" }
 	}
 
 	"cl_cross_dot_outline"
 	{
-		"Crosshair dot outline thickness"
+		"Dot outline thickness"
 		{ NUMBER -1.000000 -1.000000 }
 		{ "0.000000" }
 	}
 
+	"cl_cross_dot_outline_alpha"
+	{
+		"Dot outline transparency (0-255)"
+		{ STRING }
+		{ "" }
+	}
+
 	"cl_cross_circle_radius"
 	{
-		"Crosshair circle size"
+		"Circle size"
 		{ NUMBER 0.000000 255.000000 }
-		{ "0.000000" }
+		{ "0" }
 	}
 
 	"cl_cross_circle_thickness"
 	{
-		"Crosshair circle thickness"
+		"Circle thickness"
 		{ NUMBER 0.000000 255.000000 }
-		{ "0.000000" }
+		{ "1" }
+	}
+
+	"cl_cross_circle_color"
+		{
+		"Circle color (R G B)"
+		{ STRING }
+		{ "" }
+	}
+
+	"cl_cross_circle_alpha"
+	{
+		"Circle transparency (0-255)"
+		{ STRING }
+		{ "" }
+	}
+
+	"cl_cross_circle_outline"
+	{
+		"Circle outline thickness"
+		{ STRING }
+		{ "" }
+	}
+
+	"cl_cross_circle_outline_alpha"
+	{
+		"Circle outline transparency (0-255)"
+		{ STRING }
+		{ "" }
+	}
+
+	"cl_cross_circle_outline_inner"
+	{
+		"Outline inside of the circle"
+		{ BOOL }
+		{ "" }
 	}
 
 	"crosshair"
@@ -205,47 +351,6 @@ DESCRIPTION INFO_OPTIONS
 			"Custom 4" "4"
 		}
 		{ "0.000000" }
-	}
-
-	"senslock"
-	{
-		"Don't scale sensitivity with FOV (Skulk/Gorge)"
-		{ BOOL }
-		{ "0" }
-	}
-
-	"zoom_sensitivity_ratio"
-	{
-		"Zoom sensitivity ratio (skulk/gorge)"
-		{ NUMBER 0.000000 5.000000 }
-		{ "1.000000" }
-	}
-
-	"cl_cmhotkeys"
-	{
-		"Commander hotkeys"
-		{ STRING }
-		{ "qwerasdfzxcv" }
-	}
-
-	"cl_mutemenu"
-	{
-		"Scoreboard mute menu hotkey"
-		{
-			LIST
-			"None" "0"
-			"Left click" "1"
-			"Right click" "2"
-			"Middle mouse" "3"
-		}
-		{ "3.000000" }
-	}
-
-	"cl_showspeed"
-	{
-		"Show player speed"
-		{ BOOL }
-		{ "0" }
 	}
 
 	"cl_centerentityid"
@@ -272,27 +377,6 @@ DESCRIPTION INFO_OPTIONS
 	"cl_labelhivesight"
 	{
 		"Show alien hivesight text"
-		{ BOOL }
-		{ "1" }
-	}
-
-	"cl_dynamiclights"
-	{
-		"Dynamic lights"
-		{ BOOL }
-		{ "0" }
-	}
-
-	"r_dynamic"
-	{
-		"Dynamic lighting (non-nvidia graphics users should turn off)"
-		{ BOOL }
-		{ "1" }
-	}
-
-	"hud_fastswitch"
-	{
-		"Weapon fast-switch"
 		{ BOOL }
 		{ "1" }
 	}


### PR DESCRIPTION
- Updates to client side weapons code.
	- Reloads can now complete and update ammo count on the client (thanks @Solokiller https://github.com/Solokiller/halflife-updated).
	- Fixed clients that initiate the reload getting sent duplicate animations from the server.
	- Fixed reloads not completing if using the armory right before reloading.
	- Fixed various client weapons code checks not working correctly from the HL SDK.
		- Fixes broken animations for weapons with no ammo count.
- Fixed onos charge getting stuck.
- Lerks no longer stick to ladders when touching them while on the ground. They couldn't climb up them before anyway.
- Updates to crosshair system.
	- Fixed crosshair circle thickness not working correctly.
	- Added the following commands. The default values are blank and inherit the value nonspecific to the circle or dot if left blank.
 ```
cl_cross_circle_color 
cl_cross_circle_alpha
cl_cross_circle_outline
cl_cross_circle_outline_alpha
cl_cross_circle_outline_inner
cl_cross_dot_alpha
cl_cross_dot_outline_alpha
```
- Reorganized advanced options and added new crosshair commands to it.
- Fixed shotgun pellets showing the incorrect visuals when playing on NS v3.2 servers.
- Game version updated to 3.3b3.
