### PR TITLE
v33b3 exploit prevention

### DIFF
--- a/main/source/cl_dll/chud.h
+++ b/main/source/cl_dll/chud.h
@@ -17,6 +17,7 @@ private:
 	int							m_iSpriteCount;
 	int							m_iSpriteCountAllRes;
 	float						m_flMouseSensitivity;
+	bool						wstoggle;
 
 public:
 

--- a/main/source/cl_dll/hud_crosshairs.cpp
+++ b/main/source/cl_dll/hud_crosshairs.cpp
@@ -217,7 +217,9 @@ int CHudCrosshairs::Draw(float time)
 
 	// Draw the crosshairs.
 	if (cl_cross_thickness->value > 0.0f) {
-		gl.line_width(cl_cross_thickness->value);
+		//gl.line_width(cl_cross_thickness->value);
+		//clamp dot size to prevent using it as a full screen transparent mask for highlighting eneimies like with the /nvg night vision server plugin.
+		gl.line_width(min(cl_cross_thickness->value, ScreenHeight() * 0.3f));
 
 		float size = cl_cross_size->value;
 		float gap = cl_cross_gap->value;
@@ -276,7 +278,9 @@ int CHudCrosshairs::Draw(float time)
 			gl.color(r, g, b, dotalpha);
 		}
 
-		float size = cl_cross_dot_size->value;
+		//float size = cl_cross_dot_size->value;
+		//clamp dot size to prevent using it as a full screen transparent mask for highlighting eneimies like with the /nvg night vision server plugin.
+		float size = min(cl_cross_dot_size->value, ScreenHeight() * 0.2f);
 		Vector2D offset = Vector2D(size / 2.0f, size / 2.0f);
 
 		gl.rectangle(center - offset, center + offset);

--- a/main/source/cl_dll/hud_update.cpp
+++ b/main/source/cl_dll/hud_update.cpp
@@ -46,29 +46,35 @@ int CHud::UpdateClientData(client_data_t *cdata, float time)
 	float width = ScreenWidth();
 	float height = ScreenHeight();
 
-	//horizontal+ widescreen view correction - engine uses vertical-
-	bool wstoggle = CVAR_GET_FLOAT("cl_widescreen") != 0;
+	// Horizontal+ widescreen view correction - engine uses vertical- cropping
+
+	// Cvar to let players use old widescreen. Only allow it to change when not alive so it can't be used as a zoom toggle.
+	if (!gHUD.GetIsAlive(false))
+	{
+		wstoggle = CVAR_GET_FLOAT("cl_widescreen") != 0;
+	}
+
 	if (wstoggle)
 	{
-			m_wsFOV = atanf(tan(m_iFOV * M_PI / 360) * 0.75 * width / height) * 360 / M_PI;
+		m_wsFOV = atanf(tan(m_iFOV * M_PI / 360) * 0.75 * width / height) * 360 / M_PI;
 
-			//clamp for game balance
-			if (m_iFOV == 105 && m_wsFOV > 121)
-			{
-				m_wsFOV = 120;
-			}
-			else if (m_iFOV == 100 && m_wsFOV > 117)
-			{
-				m_wsFOV = 116;
-			}
-			else if (m_iFOV == 90 && m_wsFOV > 107)
-			{
-				m_wsFOV = 106;
-			}
-			else if (m_wsFOV < 90)
-			{
-				m_wsFOV = 90;
-			}
+		//clamp for game balance
+		if (m_iFOV == 105 && m_wsFOV > 121)
+		{
+			m_wsFOV = 120;
+		}
+		else if (m_iFOV == 100 && m_wsFOV > 117)
+		{
+			m_wsFOV = 116;
+		}
+		else if (m_iFOV == 90 && m_wsFOV > 107)
+		{
+			m_wsFOV = 106;
+		}
+		else if (m_wsFOV < 90)
+		{
+			m_wsFOV = 90;
+		}
 	}
 	else
 	{

--- a/main/source/dlls/client.cpp
+++ b/main/source/dlls/client.cpp
@@ -2336,8 +2336,8 @@ int	InconsistentFile( const edict_t *player, const char *filename, char *disconn
 	}*/
 
 	if (strstr(filename, "dlls/") != NULL) {
-		//sprintf(disconnect_message, "(%s) Your NS version differs from the server's. Go to github.com/ENSL/NS#downloads or run Natural Launcher for the latest version.\n", filename);
-		sprintf(disconnect_message, "(%s) This server is running an experimental NS build. Enable experimental build in Natural Launcher settings. github.com/ENSL/NS#downloads\n", filename);
+		sprintf(disconnect_message, "(%s) Your NS version differs from the server's. Go to github.com/ENSL/NS#downloads or run Natural Launcher for the latest version.\n", filename);
+		//sprintf(disconnect_message, "(%s) This server is running an experimental NS build. Enable experimental build in Natural Launcher settings. github.com/ENSL/NS#downloads\n", filename);
 		return 1;
 	}
 	// Cheating prone files that aren't commonly used for customization.


### PR DESCRIPTION
- Players must be dead to change cl_widescreen to prevent using it to zoom
- Restrictions to crosshairs to prevent exploits
- Updated consistency check message from server