### PR TITLE
Weapon animation fixes

### DIFF
--- a/main/delta.lst
+++ b/main/delta.lst
@@ -244,7 +244,9 @@ weapon_data_t none
 //  DEFINE_DELTA( m_fInZoom, DT_INTEGER, 1, 1.0 ),
 //  DEFINE_DELTA( m_iWeaponState, DT_INTEGER, 2, 1.0 ),
 	DEFINE_DELTA( m_iId, DT_INTEGER, 8, 1.0 ),
+	DEFINE_DELTA( iuser2, DT_INTEGER, 1, 1.0 ),							// m_fInAttack
 	DEFINE_DELTA( iuser3, DT_INTEGER, 3, 1.0 ),
+	DEFINE_DELTA( iuser4, DT_INTEGER, 1, 1.0 ),							// m_bAttackQueued
 	DEFINE_DELTA( fuser2, DT_SIGNED | DT_FLOAT, 22, 128.0  ),
 	DEFINE_DELTA( fuser3, DT_SIGNED | DT_FLOAT, 22, 128.0  )
 }

--- a/main/source/cl_dll/com_weapons.cpp
+++ b/main/source/cl_dll/com_weapons.cpp
@@ -87,11 +87,12 @@ void HUD_SendWeaponAnim( int iAnim, int body, int force )
 		// Don't actually change it.
 		if ( !g_runfuncs && !force )
 			return;
-	
+
 		g_currentanim = iAnim;
-	
+
 		// Tell animation system new info
 		gEngfuncs.pfnWeaponAnim( iAnim, body );
+		//gEngfuncs.Con_Printf("forcing animation g_currentanim:%d new anim:%d\n", g_currentanim, iAnim);
 	}
 }
 
@@ -105,6 +106,11 @@ Retrieve current predicted weapon animation
 int HUD_GetWeaponAnim( void )
 {
 	return g_currentanim;
+}
+
+void HUD_SetWeaponAnim(int anim)
+{
+	g_currentanim = anim;
 }
 
 /*

--- a/main/source/cl_dll/com_weapons.h
+++ b/main/source/cl_dll/com_weapons.h
@@ -28,6 +28,7 @@ float			UTIL_SharedRandomFloat( unsigned int seed, float low, float high );
 int				UTIL_SharedRandomLong( unsigned int seed, int low, int high );
 
 int				HUD_GetWeaponAnim( void );
+void 			HUD_SetWeaponAnim(int anim);
 void			HUD_SendWeaponAnim( int iAnim, int body, int force );
 void			HUD_PlaySound( char *sound, float volume );
 void			HUD_PlaybackEvent( int flags, const struct edict_s *pInvoker, unsigned short eventindex, float delay, float *origin, float *angles, float fparam1, float fparam2, int iparam1, int iparam2, int bparam1, int bparam2 );

--- a/main/source/cl_dll/input.cpp
+++ b/main/source/cl_dll/input.cpp
@@ -107,6 +107,8 @@ extern cvar_t *in_joystick;
 int	in_impulse	= 0;
 int	in_cancel	= 0;
 
+bool pistolHandlerDown = false;
+
 cvar_t	*m_pitch;
 cvar_t	*m_yaw;
 cvar_t	*m_forward;
@@ -823,6 +825,35 @@ void IN_AttackDownForced(void)
 void IN_AttackUpForced(void)
 {
 	KeyUpForced( &in_attack );
+}
+
+void IN_AttackHandlerDown(void)
+{
+	if (gHUD.GetCurrentWeaponID() == AVH_WEAPON_PISTOL && cl_pistoltrigger && cl_pistoltrigger->value)
+	{
+		IN_AttackDown();
+		IN_AttackUp();
+		pistolHandlerDown = true;
+	}
+	else
+	{
+		IN_AttackDown();
+	}
+}
+
+void IN_AttackHandlerUp(void)
+{
+	// Pistol binary trigger. Check if attack was down, otherwise the engine will fire the pistol when closing the console or tabbing in as it calls every -command.
+	if (gHUD.GetCurrentWeaponID() == AVH_WEAPON_PISTOL && cl_pistoltrigger && cl_pistoltrigger->value && pistolHandlerDown)
+	{
+		IN_AttackDown();
+		IN_AttackUp();
+		pistolHandlerDown = false;
+	}
+	else
+	{
+		IN_AttackUp();
+	}
 }
 
 // Special handling
@@ -1642,8 +1673,8 @@ void InitInput (void)
 	gEngfuncs.pfnAddCommand ("-moveright", IN_MoverightUp);
 	gEngfuncs.pfnAddCommand ("+speed", IN_SpeedDown);
 	gEngfuncs.pfnAddCommand ("-speed", IN_SpeedUp);
-	gEngfuncs.pfnAddCommand ("+attack", IN_AttackDown);
-	gEngfuncs.pfnAddCommand ("-attack", IN_AttackUp);
+	gEngfuncs.pfnAddCommand ("+attack", IN_AttackHandlerDown);
+	gEngfuncs.pfnAddCommand ("-attack", IN_AttackHandlerUp);
 	//gEngfuncs.pfnAddCommand ("+movement", IN_Attack2Down);
 	//gEngfuncs.pfnAddCommand ("-movement", IN_Attack2Up);
 	gEngfuncs.pfnAddCommand ("+use", IN_UseDown);
@@ -1727,7 +1758,7 @@ void InitInput (void)
 	cl_chatbeep			= gEngfuncs.pfnRegisterVariable	("cl_chatbeep", "1", FCVAR_ARCHIVE);
 	cl_mutemenu			= gEngfuncs.pfnRegisterVariable ("cl_mutemenu", "3", FCVAR_ARCHIVE);
 	cl_weaponcfgs		= gEngfuncs.pfnRegisterVariable ("cl_weaponcfgs", "1", FCVAR_ARCHIVE);
-	cl_pistoltrigger	= gEngfuncs.pfnRegisterVariable ("cl_pistoltrigger", "1", FCVAR_ARCHIVE | FCVAR_USERINFO);
+	cl_pistoltrigger	= gEngfuncs.pfnRegisterVariable ("cl_pistoltrigger", "1", FCVAR_ARCHIVE);
 	cl_cmcancellast		= gEngfuncs.pfnRegisterVariable("cl_cmcancellast", "0", FCVAR_ARCHIVE);
 
 

--- a/main/source/dlls/client.cpp
+++ b/main/source/dlls/client.cpp
@@ -2081,10 +2081,11 @@ int GetWeaponData( struct edict_s *player, struct weapon_data_s *info )
 						item->fuser2					= gun->m_flStartThrow;
 						item->fuser3					= gun->m_flReleaseThrow;
 						//item->iuser1					= gun->m_chargeReady;
-						//item->iuser2					= gun->m_fInAttack;
+						item->iuser2					= gun->m_fInAttack;
 
 						// Pass along enabled state in iuser3 (for when hives and ensnare enable and disable weapons)
 						item->iuser3					= gun->pev->iuser3;
+						item->iuser4					= gun->m_bAttackQueued;
 						
 						//item->m_flPumpTime				= max( gun->m_flPumpTime, -0.001 );
 					}

--- a/main/source/dlls/player.h
+++ b/main/source/dlls/player.h
@@ -361,9 +361,7 @@ public:
     // Added by mmcguire.
     virtual bool    GetCanUseWeapon() const { return true; }
 
-	// Networked user options
 	int m_iAutoWeaponSwap;
-	int m_iPistolTrigger;
 };
 
 #define AUTOAIM_2DEGREES  0.0348994967025

--- a/main/source/dlls/weapons.cpp
+++ b/main/source/dlls/weapons.cpp
@@ -951,8 +951,7 @@ void CBasePlayerWeapon::ItemPostFrame( void )
 {
 	// Block attacks during +movement except for lerk.
 	bool theAttackPressed = (m_pPlayer->pev->button & IN_ATTACK) && (!(m_pPlayer->pev->button & IN_ATTACK2) || m_pPlayer->pev->iuser3 == AVH_USER3_ALIEN_PLAYER3);
-	bool pistolAttackUp = (m_pPlayer->m_iPistolTrigger && m_pPlayer->m_afButtonLast & IN_ATTACK && m_pPlayer->m_afButtonReleased & IN_ATTACK && m_iId == AVH_WEAPON_PISTOL);
-
+	bool attackQueuedAndCanAttack = m_bAttackQueued && CanAttack(m_flNextPrimaryAttack, gpGlobals->time, UseDecrement());
     bool theWeaponPrimes = (this->GetWeaponPrimeTime() > 0.0f);
     bool theWeaponIsPriming = this->GetIsWeaponPriming();
     bool theWeaponIsPrimed = this->GetIsWeaponPrimed();
@@ -990,7 +989,7 @@ void CBasePlayerWeapon::ItemPostFrame( void )
     else 
 */
 
-	if ( (theAttackPressed || m_bAttackQueued || pistolAttackUp) && m_pPlayer->GetCanUseWeapon())
+	if ( (theAttackPressed || attackQueuedAndCanAttack) && m_pPlayer->GetCanUseWeapon())
 	{
 		if ((m_fInSpecialReload == 1 || m_fInSpecialReload == 2) && m_iClip != 0)
 		{
@@ -1005,11 +1004,14 @@ void CBasePlayerWeapon::ItemPostFrame( void )
 		    }
 
 			m_pPlayer->TabulateAmmo();
-			PrimaryAttack(pistolAttackUp);
+			PrimaryAttack();
         }
 		else
 		{
-			QueueAttack(pistolAttackUp);
+			if (m_pPlayer->m_afButtonPressed & IN_ATTACK)
+			{
+				QueueAttack();
+			}
 		}
 	}
 	else if (m_pPlayer->pev->button & IN_ATTACK2)

--- a/main/source/dlls/weapons.h
+++ b/main/source/dlls/weapons.h
@@ -353,8 +353,8 @@ public:
 
 	virtual void ItemPostFrame( void );	// called each frame by the player PostThink
 	// called by CBasePlayerWeapons ItemPostFrame()
-	virtual void PrimaryAttack( bool fireOnAttackUp = false ) { return; }	// do "+ATTACK"
-	virtual void QueueAttack( bool fireOnAttackUp = false ) { return; }		// queue an attack
+	virtual void PrimaryAttack( void ) { return; }				// do "+ATTACK"
+	virtual void QueueAttack(void) { return; }					// queue an attack
 	virtual void SecondaryAttack( void ) { return; }			// do "+ATTACK2"
 	virtual void Reload( void ) { return; }						// do "+RELOAD"
 	virtual void WeaponIdle( void ) { return; }					// called when no buttons pressed
@@ -385,6 +385,7 @@ public:
 	int		m_iDefaultAmmo;// how much ammo you get when you pick up this weapon as placed by a level designer.
 
 	bool	PrevAttack2Status;									// HACK: For +movement weapon animations
+	float	PrevAttack2Time;
 	float	m_flLastAnimationPlayed;	
 	bool	m_bAttackQueued;
 };

--- a/main/source/mod/AvHAcidRocketGun.cpp
+++ b/main/source/mod/AvHAcidRocketGun.cpp
@@ -212,10 +212,10 @@ int	AvHAcidRocketGun::GetDeployAnimation() const
 		break;
 
 	case AVH_WEAPON_SWIPE:
-	case AVH_WEAPON_BLINK:
 		theDeployAnimation = 8;
 		break;
 
+	case AVH_WEAPON_BLINK:
 	case AVH_WEAPON_METABOLIZE:
 		theDeployAnimation = 13;
 		break;

--- a/main/source/mod/AvHAlienAbilities.cpp
+++ b/main/source/mod/AvHAlienAbilities.cpp
@@ -86,7 +86,21 @@ int	AvHLeap::GetBarrelLength() const
 
 int	AvHLeap::GetDeployAnimation() const
 {
-	return 6;
+	int theDeployAnimation = 5;
+
+	AvHWeaponID thePreviousID = this->GetPreviousWeaponID();
+
+	switch (thePreviousID)
+	{
+	case AVH_WEAPON_BITE:
+	case AVH_WEAPON_PARASITE:
+	case AVH_ABILITY_LEAP:
+	case AVH_WEAPON_DIVINEWIND:
+		theDeployAnimation = -1;
+		break;
+	}
+
+	return theDeployAnimation;
 }
 
 float AvHLeap::GetDeployTime() const
@@ -224,11 +238,11 @@ int	AvHCharge::GetDeployAnimation() const
 		break;
 
 	case AVH_WEAPON_DEVOUR:
-		theDeployAnimation = 18;
+		theDeployAnimation = 19;
 		break;
 
 	case AVH_WEAPON_STOMP:
-		theDeployAnimation = 15;
+		theDeployAnimation = 16;
 		break;
 	}
 	

--- a/main/source/mod/AvHAlienWeapons.h
+++ b/main/source/mod/AvHAlienWeapons.h
@@ -1192,6 +1192,8 @@ public:
 	virtual void	GetEventOrigin(Vector& outOrigin) const;
 
 	virtual bool	GetFiresUnderwater() const;
+
+	virtual int		GetIdleAnimation() const;
 	
 	virtual bool	GetIsDroppable() const;
 	

--- a/main/source/mod/AvHBasePlayerWeapon.cpp
+++ b/main/source/mod/AvHBasePlayerWeapon.cpp
@@ -170,7 +170,8 @@ AvHBasePlayerWeapon::AvHBasePlayerWeapon()
     this->mEndEvent = 0;
 	this->mRange = 8012;
 	this->mDamage = 10;
-	this->mAttackButtonDownLastFrame = false;
+	//this->mAttackButtonDownLastFrame = false;
+	this->m_fInAttack = FALSE;
 	this->mTimeOfLastResupply = -1;
     this->mTimeOfLastPrime = -1;
     this->mWeaponPrimeStarted = false;
@@ -180,8 +181,6 @@ AvHBasePlayerWeapon::AvHBasePlayerWeapon()
 	this->mIsPersistent = false;
 	this->mLifetime = -1;
 #endif
-
-	this->mFireOnAttackUp = false;
 }
 void AvHBasePlayerWeapon::PrintWeaponToClient(CBaseEntity *theAvHPlayer) {
 	char msg[1024];
@@ -284,7 +283,12 @@ BOOL AvHBasePlayerWeapon::DefaultDeploy( char *szViewModel, char *szWeaponModel,
 	//this->m_pPlayer->SetAnimation(PLAYER_ANIM(iAnim));
 	
 	m_pPlayer->m_flNextAttack = UTIL_WeaponTimeBase() + this->GetDeployTime();
-	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + this->GetDeployTime() + kDeployIdleInterval;
+
+	// 2024 - Fix some +movement animation issues on aliens and also make alien idle trigger faster so they look more organic. 
+	if (m_pPlayer->pev->iuser3 > 2 && m_pPlayer->pev->iuser3 < 9)
+		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + this->GetDeployTime() + 2.0f;
+	else
+		m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + this->GetDeployTime() + kDeployIdleInterval;
 	
 	return TRUE;
 }
@@ -328,6 +332,7 @@ BOOL AvHBasePlayerWeapon::DefaultReload( int iClipSize, int iAnim, float fDelay,
 	this->m_pPlayer->SetAnimation(PLAYER_RELOAD);
 	
 	m_fInReload = TRUE;
+	m_bAttackQueued = false;
 	
 	m_flTimeWeaponIdle = UTIL_WeaponTimeBase() + kDeployIdleInterval;
 	
@@ -494,7 +499,8 @@ bool AvHBasePlayerWeapon::GetFiresUnderwater() const
 
 bool AvHBasePlayerWeapon::GetIsFiring() const
 {
-	return this->mAttackButtonDownLastFrame;
+	//return this->mAttackButtonDownLastFrame;
+	return this->m_fInAttack;
 }
 
 bool AvHBasePlayerWeapon::GetHasMuzzleFlash() const
@@ -679,6 +685,7 @@ void AvHBasePlayerWeapon::Holster( int skiplocal)
 	#endif
 
 	this->m_bAttackQueued = false;
+	this->m_fInAttack = FALSE;
 }
 
 float AvHBasePlayerWeapon::GetTimePassedThisTick() const
@@ -781,7 +788,7 @@ bool AvHBasePlayerWeapon::ProcessValidAttack(void)
 			{
 				if((this->m_flNextPrimaryAttack <= 0) && !this->m_fInSpecialReload)
 				{
-					if(!this->GetMustPressTriggerForEachShot() || !this->mAttackButtonDownLastFrame || this->mFireOnAttackUp)
+					if(!this->GetMustPressTriggerForEachShot() || !this->m_fInAttack)
 					{
 							//ALERT(at_console, "trueattack1 primammo:%d primatype:%d secammo:%d secatype:%d\n", this->m_pPlayer->m_rgAmmo[this->m_iPrimaryAmmoType], this->m_iPrimaryAmmoType, this->m_pPlayer->m_rgAmmo[this->m_iSecondaryAmmoType], this->m_iSecondaryAmmoType);
 							theAttackIsValid = true;
@@ -886,14 +893,14 @@ void AvHBasePlayerWeapon::PlaybackEvent(unsigned short inEvent, int inIparam2, i
 		int theWeaponIndex = 0;
 		AvHUser3 theUser3 = AVH_USER3_NONE;
 		int theUpgrades = 0;
-		
+
 		// When predicting weapons, play the event locally, then tell everyone else but us to play it back later
 		int flags = inFlags;
 		edict_t* theEdict;
 
 		// Pass player random seed to event, so it chooses the right direction for spread
 		int theRandomNumber = this->m_pPlayer->random_seed;
-		
+
 #if defined( AVH_CLIENT )
 		theUser3 = gHUD.GetHUDUser3();
 		theUpgrades = gHUD.GetHUDUpgrades();
@@ -906,7 +913,7 @@ void AvHBasePlayerWeapon::PlaybackEvent(unsigned short inEvent, int inIparam2, i
 
 		// For bullet spread
 		//theRandomNumber = UTIL_SharedRandomLong(this->m_pPlayer->random_seed, 1, kBulletSpreadGranularity*kBulletSpreadGranularity);
-		
+
 		// When in overwatch, the weapon is fired on the server, so the client firing the weapon won't be firing it locally first
 #if defined(AVH_SERVER)
 		if(this->mInOverwatch)
@@ -923,7 +930,7 @@ void AvHBasePlayerWeapon::PlaybackEvent(unsigned short inEvent, int inIparam2, i
 		this->GetEventAngles(theEventAngles);
 
 		float theVolume = AvHPlayerUpgrade::GetSilenceVolumeLevel(theUser3, theUpgrades);
-		
+
 		//( int flags, const edict_t *pInvoker, unsigned short eventindex, float delay, float *origin, float *angles, float fparam1, float fparam2, int iparam1, int iparam2, int bparam1, int bparam2 );
 		PLAYBACK_EVENT_FULL(flags, this->m_pPlayer->edict(), theEvent, 0, (float *)&theEventOrigin, (float *)&theEventAngles, theVolume, 0.0, theRandomNumber, inIparam2, 0, 0 );
 	}
@@ -1027,17 +1034,18 @@ void AvHBasePlayerWeapon::SetNextAttack(void)
 }
 
 
-void AvHBasePlayerWeapon::PrimaryAttack(bool fireOnAttackUp)
+void AvHBasePlayerWeapon::PrimaryAttack(void)
 {
     if (this->ProcessValidAttack())
     {
-
-        if (!this->mAttackButtonDownLastFrame)
+        //if (!this->mAttackButtonDownLastFrame)
+		if (!this->m_fInAttack)
         {
-            this->PlaybackEvent(this->mStartEvent);
-            this->mAttackButtonDownLastFrame = true;
+			this->PlaybackEvent(this->mStartEvent);
+            //this->mAttackButtonDownLastFrame = true;
+			this->m_fInAttack = TRUE;
         }
-    		
+    	
         this->PlaybackEvent(this->mEvent, this->GetShootAnimation());
         this->SetAnimationAndSound();
 	
@@ -1059,7 +1067,6 @@ void AvHBasePlayerWeapon::PrimaryAttack(bool fireOnAttackUp)
 
         this->DeductCostForShot();
         this->SetNextAttack();
-        
     }
 }
 
@@ -1379,10 +1386,12 @@ void AvHBasePlayerWeapon::WeaponIdle(void)
 //	//gEngfuncs.Con_Printf("during idle, clip is %d\n", sz);
 //#endif
 
-	if(this->mAttackButtonDownLastFrame)
+	//if(this->mAttackButtonDownLastFrame)
+	if (this->m_fInAttack)
 	{
 		this->PlaybackEvent(this->mEndEvent);
-		this->mAttackButtonDownLastFrame = false;
+		//this->mAttackButtonDownLastFrame = false;
+		this->m_fInAttack = FALSE;
 	}
 	
 	ResetEmptySound();
@@ -1391,8 +1400,12 @@ void AvHBasePlayerWeapon::WeaponIdle(void)
 
 	if(this->m_flTimeWeaponIdle <= UTIL_WeaponTimeBase())
 	{
+		// +movement transitional animation fix
+#ifdef AVH_CLIENT
+		if (gpGlobals->time - this->PrevAttack2Time > 1.0f)
+#endif
 		this->SendWeaponAnim(this->GetIdleAnimation());
-			
+
 		this->m_pPlayer->SetAnimation(PLAYER_IDLE);
 			
 		this->SetNextIdle();

--- a/main/source/mod/AvHBasePlayerWeapon.h
+++ b/main/source/mod/AvHBasePlayerWeapon.h
@@ -177,7 +177,7 @@ public:
 
 	virtual void    Precache();
 
-	virtual void    PrimaryAttack(bool fireOnAttackUp = false);
+	virtual void    PrimaryAttack();
 
     virtual void    Reload();
 
@@ -247,7 +247,7 @@ protected:
 
 	float					mRange;
 	float					mDamage;
-	bool					mAttackButtonDownLastFrame;
+	//bool					mAttackButtonDownLastFrame;
 	float					mTimeOfLastResupply;
     
     float                   mTimeOfLastPrime;
@@ -261,8 +261,6 @@ protected:
 	
     // sounds               
     CStringList				mFireSounds;
-
-	bool					mFireOnAttackUp;
 };
 
 #endif

--- a/main/source/mod/AvHBite2.cpp
+++ b/main/source/mod/AvHBite2.cpp
@@ -73,9 +73,11 @@ int	AvHBite2::GetDeployAnimation() const
 
 	switch(thePreviousID)
 	{
+	case AVH_WEAPON_PRIMALSCREAM:
+		theDeployAnimation = -1;
+		break;
 	case AVH_WEAPON_UMBRA:
 	case AVH_WEAPON_SPORES:
-	//case AVH_WEAPON_PRIMALSCREAM:
 		theDeployAnimation = 12;
 		break;
 	}

--- a/main/source/mod/AvHClaws.cpp
+++ b/main/source/mod/AvHClaws.cpp
@@ -94,8 +94,8 @@ float AvHClaws::GetRateOfFire() const
 int	AvHClaws::GetDeployAnimation() const
 {
 	// Look at most recently used weapon and see if we can transition from it
-	int theDeployAnimation = 9;
-	
+	int theDeployAnimation = 27;
+
 	AvHWeaponID thePreviousID = this->GetPreviousWeaponID();
 	
 	switch(thePreviousID)

--- a/main/source/mod/AvHDivineWind.cpp
+++ b/main/source/mod/AvHDivineWind.cpp
@@ -98,7 +98,21 @@ float AvHDivineWind::GetRateOfFire() const
 
 int	AvHDivineWind::GetDeployAnimation() const
 {
-	return 13;
+	int theDeployAnimation = 5;
+
+	AvHWeaponID thePreviousID = this->GetPreviousWeaponID();
+
+	switch (thePreviousID)
+	{
+	case AVH_WEAPON_BITE:
+	case AVH_WEAPON_PARASITE:
+	case AVH_ABILITY_LEAP:
+	case AVH_WEAPON_DIVINEWIND:
+		theDeployAnimation = -1;
+		break;
+	}
+
+	return theDeployAnimation;
 }
 
 bool AvHDivineWind::GetFiresUnderwater() const

--- a/main/source/mod/AvHEvents.cpp
+++ b/main/source/mod/AvHEvents.cpp
@@ -119,6 +119,8 @@
 #include "AvHHulls.h"
 #include "AvHServerVariables.h"
 
+#include "cl_dll/com_weapons.h"
+
 //extern AvHKnife				gKnife;
 //extern AvHMachineGun		gMachineGun;
 //extern AvHPistol			gPistol;
@@ -1392,7 +1394,7 @@ void EV_SpitGun(struct event_args_s* inArgs)
 		{
 			V_PunchAxis( 0, gEngfuncs.pfnRandomFloat( -theHalfSpread, theHalfSpread ) );
 		}
-		
+
 		gEngfuncs.pEventAPI->EV_WeaponAnimation(inArgs->iparam2, 2);
 	}
 }
@@ -3606,10 +3608,13 @@ void EV_DistressBeacon(struct event_args_s* inArgs)
 
 void EV_WeaponAnimation(struct event_args_s* inArgs)
 {
+	//gEngfuncs.Con_Printf("ev_weapanim attempt islocal:%d anim:%d g_currentanim:%d clienttime:%f\n", EV_IsLocal(inArgs->entindex), inArgs->iparam2, HUD_GetWeaponAnim(), gEngfuncs.GetClientTime());
 	// General x-punch axis
 	if(EV_IsLocal(inArgs->entindex))
 	{
 		int theAnimation = max(inArgs->iparam2, 0);
+		// 2024 - Set this here to be checked in weapons think later to force animations if needed since event playback doesn't always work.
+		HUD_SetWeaponAnim(theAnimation);
 		gEngfuncs.pEventAPI->EV_WeaponAnimation(theAnimation, 2);
 	}
 }

--- a/main/source/mod/AvHGamerules.cpp
+++ b/main/source/mod/AvHGamerules.cpp
@@ -947,15 +947,10 @@ void AvHGamerules::ClientUserInfoChanged(CBasePlayer *pPlayer, char *infobuffer)
 	// NOTE: Not currently calling down to parent CHalfLifeTeamplay 
 
 	const char* theAutoWeapSwapValue = g_engfuncs.pfnInfoKeyValue(infobuffer, "cl_weaponswap");
-	if (theAutoWeapSwapValue) 
+
+	if (theAutoWeapSwapValue)
 	{
 		pPlayer->m_iAutoWeaponSwap = atoi(theAutoWeapSwapValue);
-	}
-
-	const char* thePistolTriggerValue = g_engfuncs.pfnInfoKeyValue(infobuffer, "cl_pistoltrigger");
-	if (thePistolTriggerValue) 
-	{
-		pPlayer->m_iPistolTrigger = atoi(thePistolTriggerValue);
 	}
 }
 

--- a/main/source/mod/AvHGrenade.cpp
+++ b/main/source/mod/AvHGrenade.cpp
@@ -238,16 +238,18 @@ BOOL AvHGrenade::IsUseable(void)
 }
 
 
-void AvHGrenade::PrimaryAttack(bool fireOnAttackUp)
+void AvHGrenade::PrimaryAttack(void)
 {
  
     if (this->ProcessValidAttack())
     {
 
-        if (!this->mAttackButtonDownLastFrame)
+        //if (!this->mAttackButtonDownLastFrame)
+        if (!this->m_fInAttack)
         {
             this->PlaybackEvent(this->mStartEvent);
-            this->mAttackButtonDownLastFrame = true;
+            //this->mAttackButtonDownLastFrame = true;
+            this->m_fInAttack = TRUE;
         }
     		
 	    if (m_flStartThrow == 0)

--- a/main/source/mod/AvHHudRender.cpp
+++ b/main/source/mod/AvHHudRender.cpp
@@ -141,6 +141,7 @@
 #include "AvHAlienAbilityConstants.h"
 #include <list>
 #include "../common/entity_types.h"
+#include "cl_dll/com_weapons.h"
 
 void IN_GetMousePos( int *mx, int *my );
 
@@ -3819,6 +3820,9 @@ void AvHHud::RenderAlienUI()
 
     if (GetHUDUser3() == AVH_USER3_ALIEN_EMBRYO)
     {
+		// 2024 - Set this so deploy animations play properly once out of the egg. This is here because weapons think doesn't happen durring gestation.
+		HUD_SetWeaponAnim(-1);
+
 		if (mMembraneSprite)
 		{
             AvHSpriteSetRenderMode(kRenderTransAdd);

--- a/main/source/mod/AvHMarineWeapons.h
+++ b/main/source/mod/AvHMarineWeapons.h
@@ -233,9 +233,9 @@ public:
 
 	virtual void	Precache(void);
 
-	virtual void	PrimaryAttack(bool fireOnAttackUp = false);
+	virtual void	PrimaryAttack();
 
-	virtual void	QueueAttack(bool fireOnAttackUp);
+	virtual void	QueueAttack(void);
 	
 	virtual void	Spawn();
 	
@@ -624,7 +624,7 @@ public:
 
     virtual void    WeaponIdle();
 
-    virtual void    PrimaryAttack(bool fireOnAttackUp = false);
+    virtual void    PrimaryAttack(void);
     
 protected: 
 

--- a/main/source/mod/AvHParasiteGun.cpp
+++ b/main/source/mod/AvHParasiteGun.cpp
@@ -109,7 +109,21 @@ int AvHParasiteGun::GetDamageType() const
 
 int	AvHParasiteGun::GetDeployAnimation() const
 {
-	return 6;
+	int theDeployAnimation = 5;
+
+	AvHWeaponID thePreviousID = this->GetPreviousWeaponID();
+
+	switch (thePreviousID)
+	{
+	case AVH_WEAPON_BITE:
+	case AVH_WEAPON_PARASITE:
+	case AVH_ABILITY_LEAP:
+	case AVH_WEAPON_DIVINEWIND:
+		theDeployAnimation = -1;
+		break;
+	}
+
+	return theDeployAnimation;
 }
 
 bool AvHParasiteGun::GetFiresUnderwater() const

--- a/main/source/mod/AvHPistol.cpp
+++ b/main/source/mod/AvHPistol.cpp
@@ -174,25 +174,16 @@ void AvHPistol::Precache()
 	this->mEvent = PRECACHE_EVENT(1, kHGEventName);
 }
 
-void AvHPistol::PrimaryAttack(bool fireOnAttackUp)
+void AvHPistol::PrimaryAttack()
 {
 	this->m_bAttackQueued = false;
-	this->mFireOnAttackUp = fireOnAttackUp;
-	if (fireOnAttackUp)
-	{
-		this->m_iPlayEmptySound = true;
-	}
+
 	AvHMarineWeapon::PrimaryAttack();
-	this->mFireOnAttackUp = false;
 }
 
-void AvHPistol::QueueAttack(bool fireOnAttackUp)
+void AvHPistol::QueueAttack(void)
 {
-	if (!this->mAttackButtonDownLastFrame || fireOnAttackUp)
-	{
-		this->m_bAttackQueued = true;
-		this->mAttackButtonDownLastFrame = false;
-	}
+	this->m_bAttackQueued = true;
 }
 
 void AvHPistol::Spawn()

--- a/main/source/mod/AvHPlayer.cpp
+++ b/main/source/mod/AvHPlayer.cpp
@@ -4863,6 +4863,7 @@ void AvHPlayer::PlayerConstructUse()
         if((this->mTimeOfLastConstructUseAnimation == 0) || (gpGlobals->time > (this->mTimeOfLastConstructUseAnimation + kConstructAnimationInterval)))
         {
             // Play special builder animation
+            this->pev->weaponanim = kConstructAnimationIndex;
             PLAYBACK_EVENT_FULL(0, this->edict(), gWeaponAnimationEventID, 0, this->pev->origin, (float *)&g_vecZero, 0.0, 0.0, 0, kConstructAnimationIndex, 0, 0 );
 
             // Delay idle

--- a/main/source/mod/AvHPlayer.h
+++ b/main/source/mod/AvHPlayer.h
@@ -868,7 +868,6 @@ private:
 
 	bool				mUsedKilled;
 
-
 	//TODO: remove this system from AvHPlayer and create an 
 	// explicit balance forwarding class registered to each
 	// client instead.  This functionality is tangential to

--- a/main/source/mod/AvHPrimalScream.cpp
+++ b/main/source/mod/AvHPrimalScream.cpp
@@ -82,14 +82,18 @@ bool AvHPrimalScream::GetFiresUnderwater() const
 int	AvHPrimalScream::GetDeployAnimation() const
 {
 	// Look at most recently used weapon and see if we can transition from it
-	int theDeployAnimation = -1;
+	int theDeployAnimation = 1;
 	
 	AvHWeaponID thePreviousID = this->GetPreviousWeaponID();
 	
 	switch(thePreviousID)
 	{
 	case AVH_WEAPON_BITE2:
-		theDeployAnimation = 9;
+		theDeployAnimation = -1;
+		break;
+	case AVH_WEAPON_SPORES:
+	case AVH_WEAPON_UMBRA:
+		theDeployAnimation = 12;
 		break;
 	case AVH_WEAPON_SPIKE:
 		theDeployAnimation = 8;

--- a/main/source/mod/AvHSpitGun.cpp
+++ b/main/source/mod/AvHSpitGun.cpp
@@ -177,13 +177,14 @@ int	AvHSpitGun::GetDamageType() const
 int	AvHSpitGun::GetDeployAnimation() const
 {
 	// Look at most recently used weapon and see if we can transition from it
-	int theDeployAnimation = 7;
+	int theDeployAnimation = 11;
 
 	AvHWeaponID thePreviousID = this->GetPreviousWeaponID();
 
 	switch(thePreviousID)
 	{
 	case AVH_WEAPON_SPIT:
+	case AVH_WEAPON_BILEBOMB:
 		theDeployAnimation = -1;
 		break;
 

--- a/main/source/mod/AvHSpores.cpp
+++ b/main/source/mod/AvHSpores.cpp
@@ -247,14 +247,18 @@ int	AvHSpore::GetShootAnimation() const
 int	AvHSpore::GetDeployAnimation() const
 {
 	// Look at most recently used weapon and see if we can transition from it
-	int theDeployAnimation = -1;
+	int theDeployAnimation = 2;
 
 	AvHWeaponID thePreviousID = this->GetPreviousWeaponID();
 
 	switch(thePreviousID)
 	{
 	case AVH_WEAPON_BITE2:
+	case AVH_WEAPON_PRIMALSCREAM:
 		theDeployAnimation = 9;
+		break;
+	case AVH_WEAPON_UMBRA:
+		theDeployAnimation = -1;
 		break;
 	case AVH_WEAPON_SPIKE:
 		theDeployAnimation = 8;

--- a/main/source/mod/AvHStomp.cpp
+++ b/main/source/mod/AvHStomp.cpp
@@ -224,6 +224,11 @@ bool AvHStomp::GetFiresUnderwater() const
 	return false;
 }
 
+int AvHStomp::GetIdleAnimation() const
+{
+	return 3;
+}
+
 bool AvHStomp::GetIsDroppable() const
 {
 	return false;

--- a/main/source/mod/AvHUmbraGun.cpp
+++ b/main/source/mod/AvHUmbraGun.cpp
@@ -163,14 +163,18 @@ float AvHUmbraGun::GetRateOfFire() const
 
 int	AvHUmbraGun::GetDeployAnimation() const
 {
-	int theDeployAnimation = -1;
+	int theDeployAnimation = 2;
 	
 	AvHWeaponID thePreviousID = this->GetPreviousWeaponID();
 	
 	switch(thePreviousID)
 	{
 	case AVH_WEAPON_BITE2:
+	case AVH_WEAPON_PRIMALSCREAM:
 		theDeployAnimation = 9;
+		break;
+	case AVH_WEAPON_SPORES:
+		theDeployAnimation = -1;
 		break;
 	case AVH_WEAPON_SPIKE:
 		theDeployAnimation = 8;

--- a/main/source/mod/AvHWebSpinner.cpp
+++ b/main/source/mod/AvHWebSpinner.cpp
@@ -297,6 +297,7 @@ int AvHWebSpinner::GetDeployAnimation() const
 	switch(thePreviousID)
 	{
 	case AVH_WEAPON_WEBSPINNER:
+	case AVH_WEAPON_HEALINGSPRAY:
 		theDeployAnimation = -1;
 		break;
 

--- a/main/source/mod/AvHWelder.cpp
+++ b/main/source/mod/AvHWelder.cpp
@@ -246,7 +246,8 @@ void AvHWelder::Holster( int skiplocal )
 void AvHWelder::WeaponIdle(void)
 {
 #ifdef AVH_SERVER
-	if(this->GetIsWelding() && this->mAttackButtonDownLastFrame) 
+	//if(this->GetIsWelding() && this->mAttackButtonDownLastFrame) 
+	if (this->GetIsWelding() && this->m_fInAttack)
 	{
 		PLAYBACK_EVENT_FULL(0, this->m_pPlayer->edict(), gWelderConstEventID, 0, this->m_pPlayer->pev->origin, (float *)&g_vecZero, 0.0, 0.0, 1, 0, 0, 0 );
 		this->SetIsWelding(false);


### PR DESCRIPTION
- Fixed animation issues with pistol binary trigger and moved the binary triggering to client code
- Fixed reload animation not always playing when reloading
- Fixed the ammo count for the pistol decrementing briefly when releasing attack (old issue from before the binary trigger)
- Fixed numerous incorrect or broken alien weapon animations on every class
- Added transitional animation out of gorge building